### PR TITLE
Change CoroutineExecuterBehaviour component to be hidden

### DIFF
--- a/Packages/UGF.Coroutines/Runtime/Unity/CoroutineExecuterBehaviour.cs
+++ b/Packages/UGF.Coroutines/Runtime/Unity/CoroutineExecuterBehaviour.cs
@@ -5,6 +5,7 @@ namespace UGF.Coroutines.Runtime.Unity
     /// <summary>
     /// Represents a empty 'MonoBehaviour' component used to run coroutines.
     /// </summary>
+    [AddComponentMenu("")]
     public class CoroutineExecuterBehaviour : MonoBehaviour
     {
     }


### PR DESCRIPTION
- Add `AddComponentMenu` attribute for `CoroutineExecuterBehaviour` with empty path to hide component from _Add Component_ menu in inspector.